### PR TITLE
Fix dead link: ZKLib -> ArkLib

### DIFF
--- a/data/research-tracks.tsx
+++ b/data/research-tracks.tsx
@@ -253,7 +253,7 @@ export const researchTracksData: ResearchTrack[] = [
       },
       {
         title: 'Formally Verified SNARKs in Lean',
-        url: 'https://github.com/Verified-zkEVM/ZKLib',
+        url: 'https://github.com/Verified-zkEVM/ArkLib',
         type: 'code',
       },
       {
@@ -262,8 +262,8 @@ export const researchTracksData: ResearchTrack[] = [
         type: 'code',
       },
       {
-        title: 'zkLib Lean blueprint',
-        url: 'https://verified-zkevm.github.io/ZKLib/blueprint/index.html',
+        title: 'ArkLib Lean blueprint',
+        url: 'https://verified-zkevm.github.io/ArkLib/blueprint/index.html',
         type: 'website',
       },
     ],


### PR DESCRIPTION
The ZKLib lean project is now called "ArkLib" to be consistent with the fact that it covers proof systems that can either be zk or not zk. This PR fixes these links.

In particular, https://verified-zkevm.github.io/ArkLib/blueprint/index.html is the correct link to the blueprint - the current link https://verified-zkevm.github.io/ZKLib/blueprint/index.html is now 404, which you can observe by clicking.