### PR TITLE
fix: Fix "We're here" marker position

### DIFF
--- a/components/Timeline.tsx
+++ b/components/Timeline.tsx
@@ -1,5 +1,4 @@
 import { Card } from '@/components/ui/primitives';
-import { getCurrentDate } from '@/lib/utils';
 import { timelineData, TIMELINE_CONFIG } from '@/data/timeline';
 
 type TimelineDate = {
@@ -11,7 +10,7 @@ const getTimelineDate = (): TimelineDate => {
   const date = new Date();
   return {
     year: date.getFullYear(),
-    month: 12,
+    month: date.getMonth() + 1,
   };
 };
 
@@ -23,11 +22,11 @@ const getMonthsSinceStart = (date: TimelineDate) => {
 // Helper function to calculate grid position percentage
 const getGridOffsetPercentage = (date: TimelineDate) => {
   const currentMonths = getMonthsSinceStart(date);
+  // Use the same calculation as timeline bars for consistency
+  const totalMonths = TIMELINE_CONFIG.TOTAL_MONTHS + 12;
+  const percentage = (currentMonths / totalMonths) * 100;
 
-  // Adjust for grid
-  // Each column represents 12 months, so we need to map the percentage to the grid
-  const gridOffset = (currentMonths / 12) / (TIMELINE_CONFIG.END_YEAR - TIMELINE_CONFIG.START_YEAR + 1) * 100;
-  return gridOffset;
+  return percentage;
 }
 
 const getGridRange = (

--- a/components/Timeline.tsx
+++ b/components/Timeline.tsx
@@ -27,7 +27,7 @@ const getGridOffsetPercentage = (date: TimelineDate) => {
   const percentage = (currentMonths / totalMonths) * 100;
 
   return percentage;
-}
+};
 
 const getGridRange = (
   startDate: { year: number; month: number },

--- a/components/Timeline.tsx
+++ b/components/Timeline.tsx
@@ -2,16 +2,33 @@ import { Card } from '@/components/ui/primitives';
 import { getCurrentDate } from '@/lib/utils';
 import { timelineData, TIMELINE_CONFIG } from '@/data/timeline';
 
+type TimelineDate = {
+  year: number;
+  month: number;
+};
+
+const getTimelineDate = (): TimelineDate => {
+  const date = new Date();
+  return {
+    year: date.getFullYear(),
+    month: 12,
+  };
+};
+
 // Helper function to convert date to months since start
-const getMonthsSinceStart = (date: { year: number; month: number }) => {
+const getMonthsSinceStart = (date: TimelineDate) => {
   return (date.year - TIMELINE_CONFIG.START_YEAR) * 12 + (date.month - 1);
 };
 
 // Helper function to calculate grid position percentage
-const getGridPosition = (date: { year: number; month: number }) => {
-  const totalMonths = getMonthsSinceStart(date);
-  return (totalMonths / TIMELINE_CONFIG.TOTAL_MONTHS) * 100;
-};
+const getGridOffsetPercentage = (date: TimelineDate) => {
+  const currentMonths = getMonthsSinceStart(date);
+
+  // Adjust for grid
+  // Each column represents 12 months, so we need to map the percentage to the grid
+  const gridOffset = (currentMonths / 12) / (TIMELINE_CONFIG.END_YEAR - TIMELINE_CONFIG.START_YEAR + 1) * 100;
+  return gridOffset;
+}
 
 const getGridRange = (
   startDate: { year: number; month: number },
@@ -28,12 +45,8 @@ const getGridRange = (
 };
 
 export function Timeline() {
-  const now = getCurrentDate();
-  const CURRENT_DATE = {
-    year: now.getFullYear(),
-    month: now.getMonth(),
-  };
-  const currentOffset = getGridPosition(CURRENT_DATE);
+  const CURRENT_DATE = getTimelineDate();
+  const weHereMarkerOffsetPercentage = getGridOffsetPercentage(CURRENT_DATE);
 
   return (
     <Card className="bg-white border-slate-200 p-4 overflow-clip">
@@ -67,7 +80,7 @@ export function Timeline() {
           <div
             className="absolute w-0 border-l border-dashed border-slate-600/30 animate-pulse-subtle"
             style={{
-              left: `${currentOffset}%`,
+              left: `${weHereMarkerOffsetPercentage}%`,
               top: '1.5rem', // Start after year labels
               bottom: '0', // Extend to bottom
               zIndex: 0,

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -4,9 +4,3 @@ import { twMerge } from 'tailwind-merge';
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs));
 }
-
-export function getCurrentDate() {
-  // Using a fixed date for development and demo purposes
-  // This ensures consistent behavior across the application
-  return new Date('2025-03-13T16:59:48+07:00');
-}


### PR DESCRIPTION
### Description

- Resolve https://github.com/ReamLabs/leanroadmap/issues/35
- Remove fixed date in utils and rewrite marker position calculation
<img width="1454" height="843" alt="Screenshot 2568-09-14 at 09 50 14" src="https://github.com/user-attachments/assets/6fa5130b-2fce-4764-8fc7-c39143607c3c" />
